### PR TITLE
[Fix] Fix --attack_mask argument in shell script

### DIFF
--- a/lisa-cnn-attack/run_noise_to_bigimage.sh
+++ b/lisa-cnn-attack/run_noise_to_bigimage.sh
@@ -7,5 +7,5 @@ python apply_noise_to_bigger_image.py \
     --big_image ./misc/uw17-cropped.png \
     --model_path ./optimization_output/${SIGN_PREFIX}/model/${SIGN_PREFIX}-${EPOCH} \
     --output_path ./misc/uw17-octagon-noise-npadd.png \
-    --attack_mask ./masks/octagon_mask_mergelayers.png
+    --attack_mask ./masks/octagon.png
 


### PR DESCRIPTION
The repository doesn't include `./lisa-cnn-attack/masks/octagon_mask_mergelayers.png`.
I checked the resulting image by `./lisa-cnn-attack/run_noise_to_bigimage.sh` with `./misc/uw17-octagon-noise-npadd.png` argument and found it seems like what I expected.